### PR TITLE
Neue Spalten im ZFI-Grid

### DIFF
--- a/Leibit.Client.WPF/Windows/TrainProgressInformation/Views/TrainProgressInformationView.xaml
+++ b/Leibit.Client.WPF/Windows/TrainProgressInformation/Views/TrainProgressInformationView.xaml
@@ -77,6 +77,7 @@
 
         <controls:LeibitDataGrid.Columns>
             <controls:LeibitDataGridColumn Header="Btrst" FieldName="Station.ShortSymbol" />
+            <controls:LeibitDataGridColumn Header="Gattung" FieldName="CurrentTrain.Train.Type" />
             <controls:LeibitDataGridColumn Header="ZN" FieldName="TrainNumber" />
             <controls:LeibitDataGridColumn Header="Ankunft" FieldName="Arrival" />
             <controls:LeibitDataGridColumn Header="Abfahrt" FieldName="Departure" />
@@ -89,24 +90,29 @@
             <controls:LeibitDataGridColumn Header="Zugstatus" FieldName="State" />
             <controls:LeibitDataGridColumn Header="Gleis" FieldName="Track.Name" />
             <controls:LeibitDataGridColumn Header="Abw. Gleis" FieldName="LiveTrack.Name" />
+            <controls:LeibitDataGridColumn Header="Start" FieldName="CurrentTrain.Train.Start" />
+            <controls:LeibitDataGridColumn Header="Ziel" FieldName="CurrentTrain.Train.Destination" />
         </controls:LeibitDataGrid.Columns>
 
         <controls:LeibitDataGrid.DefaultLayout>
             <entities:GridSetting>
                 <entities:GridSetting.ColumnSettings>
                     <entities:GridColumnSetting ColumnName="Station.ShortSymbol" Position="0" Width="40"/>
-                    <entities:GridColumnSetting ColumnName="TrainNumber" Position="1" Width="50"/>
-                    <entities:GridColumnSetting ColumnName="Arrival" Position="2" Width="55"/>
-                    <entities:GridColumnSetting ColumnName="Departure" Position="3" Width="55"/>
-                    <entities:GridColumnSetting ColumnName="DelayString" Position="4" Width="30"/>
-                    <entities:GridColumnSetting ColumnName="ExpectedArrival" Position="5" Width="45"/>
-                    <entities:GridColumnSetting ColumnName="ExpectedDeparture" Position="6" Width="45"/>
-                    <entities:GridColumnSetting ColumnName="DelayInfo" Position="7" Width="30"/>
-                    <entities:GridColumnSetting ColumnName="LocalOrders" Position="8" Width="40"/>
-                    <entities:GridColumnSetting ColumnName="CurrentStation.Name" Position="9" Width="200"/>
-                    <entities:GridColumnSetting ColumnName="State" Position="10" Width="65"/>
-                    <entities:GridColumnSetting ColumnName="Track.Name" Position="11" Width="50"/>
-                    <entities:GridColumnSetting ColumnName="LiveTrack.Name" Position="12" Width="65"/>
+                    <entities:GridColumnSetting ColumnName="CurrentTrain.Train.Type" Position="1" Width="30"/>
+                    <entities:GridColumnSetting ColumnName="TrainNumber" Position="2" Width="50"/>
+                    <entities:GridColumnSetting ColumnName="Arrival" Position="3" Width="55"/>
+                    <entities:GridColumnSetting ColumnName="Departure" Position="4" Width="55"/>
+                    <entities:GridColumnSetting ColumnName="DelayString" Position="5" Width="30"/>
+                    <entities:GridColumnSetting ColumnName="ExpectedArrival" Position="6" Width="45"/>
+                    <entities:GridColumnSetting ColumnName="ExpectedDeparture" Position="7" Width="45"/>
+                    <entities:GridColumnSetting ColumnName="DelayInfo" Position="8" Width="30"/>
+                    <entities:GridColumnSetting ColumnName="LocalOrders" Position="9" Width="40"/>
+                    <entities:GridColumnSetting ColumnName="CurrentStation.Name" Position="10" Width="200"/>
+                    <entities:GridColumnSetting ColumnName="State" Position="11" Width="65"/>
+                    <entities:GridColumnSetting ColumnName="Track.Name" Position="12" Width="50"/>
+                    <entities:GridColumnSetting ColumnName="LiveTrack.Name" Position="13" Width="65"/>
+                    <entities:GridColumnSetting ColumnName="CurrentTrain.Train.Start" Position="14" Width="120"/>
+                    <entities:GridColumnSetting ColumnName="CurrentTrain.Train.Destination" Position="15" Width="120"/>
                 </entities:GridSetting.ColumnSettings>
 
                 <entities:GridSetting.GroupedColumns>

--- a/Leibit.Controls.WPF/LeibitDataGrid/LeibitDataGrid.xaml.cs
+++ b/Leibit.Controls.WPF/LeibitDataGrid/LeibitDataGrid.xaml.cs
@@ -515,9 +515,10 @@ namespace Leibit.Controls
                 {
                     var gridColumn = new DataGridTextColumn();
                     gridColumn.Header = column.Header;
+                    gridColumn.MinWidth = 2;
                     gridColumn.Binding = new Binding(column.FieldName);
                     gridColumn.ElementStyle = new Style(typeof(TextBlock));
-                    gridColumn.ElementStyle.Setters.Add(new Setter(MarginProperty, new Thickness(0, 5, 0, 5)));
+                    gridColumn.ElementStyle.Setters.Add(new Setter(MarginProperty, new Thickness(2, 5, 2, 5)));
                     dataGrid.Columns.Add(gridColumn);
                 }
             }


### PR DESCRIPTION
Dem ZFI Grid wurden die neuen Spalten "Gattung", "Start" und "Ziel" hinzugefügt. Die Mindestbreite für Spalten wurde (für alle Grids) auf 2 Pixel reduziert, damit die Spalten zusammengeschoben werden können, sodass sie praktisch unsichtbar sind.

Die Breite von 2 Pixeln hat den Vorteil, dass man im Gridkopf sieht, dass sort noch Spalten sind. Außerdem erleichtert es das wieder auseinander ziehen, insb. am rechten Rand des Grids.