### PR TITLE
Verzeichnisprüfung

### DIFF
--- a/Leibit.BLL/SettingsBLL.cs
+++ b/Leibit.BLL/SettingsBLL.cs
@@ -197,9 +197,11 @@ namespace Leibit.BLL
                 }
 
                 if (!Directory.Exists(Estw.Value))
-                    Messages.Add(String.Format("Das Verzeichnis '{0}' existiert nicht.", Estw.Value));
-                else if (!File.Exists(Path.Combine(Estw.Value, "estw_sim.exe")))
-                    Messages.Add(String.Format("Das Verzeichnis '{0}' ist kein gültiges ESTWsim-Verzeichnis.", Estw.Value));
+                    Messages.Add($"Das Verzeichnis '{Estw.Value}' existiert nicht.");
+                else if (!Directory.Exists(Path.Combine(Estw.Value, Constants.SCHEDULE_FOLDER))
+                    || !Directory.Exists(Path.Combine(Estw.Value, Constants.LOCAL_ORDERS_FOLDER))
+                    || !Directory.Exists(Path.Combine(Estw.Value, Constants.SHARED_DELAY_FOLDER)))
+                    Messages.Add($"Das Verzeichnis '{Estw.Value}' ist kein gültiges ESTWsim-Verzeichnis.");
             }
 
             if (Setting.DelayJustificationMinutes <= 0)


### PR DESCRIPTION
Bei der Validierung, ob ein angegebener Pfad ein gültiger Pfad zu einer ESTWsim Installation ist, wird nun nicht mehr die Existenz der estw_sim.exe geprüft. Stattdessen wird geprüft, ob die Ordner "Bahnhof Fahrplan", "Bahnhof Anweisungen" und "Kommunikation" vorhanden sind.