### PR TITLE
LeiBIT.exe startet nicht

### DIFF
--- a/Leibit.Client.WPF/App.xaml
+++ b/Leibit.Client.WPF/App.xaml
@@ -15,6 +15,17 @@
                 <Setter Property="NoButtonContent" Value="Nein" />
                 <Setter Property="CancelButtonContent" Value="Abbrechen" />
             </Style>
+
+            <Style TargetType="xctk:ColorPicker">
+                <Setter Property="DropDownBackground">
+                    <Setter.Value>
+                        <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
+                            <GradientStop Color="#FFFAFBFB" Offset="0" />
+                            <GradientStop Color="#FFF4F4F4" Offset="1" />
+                        </LinearGradientBrush>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>


### PR DESCRIPTION
Fixes #61 

Das Problem lässt sich auf einen Bug im ColorPicker im WPF Toolkit in der aktuell verwendeten Version 3.6 zurückführen. Das Default Theme verweist auf eine statische Ressource, die es nicht gibt. Dadurch, dass das Einstellungsfenster beim Start geöffnet wird, ist die komplette LeiBIT.exe abgeschmiert.

Siehe auch https://forums.xceed.com/forums/topic/colorpicker-dependencyproperty-unsetvalue-exception-if-used-in-listview-item/