### PR TITLE
Überarbeitung der Namen der Betriebsstellen

### DIFF
--- a/Leibit.Core/Data/nhth/FB.xml
+++ b/Leibit.Core/Data/nhth/FB.xml
@@ -54,7 +54,7 @@
     </track>
   </station>
 
-  <station name="Bebra Pbf" short="FB" refNr="23" scheduleFile="g23_____.abf" localOrderFile="bf23____.ABF">
+  <station name="Bebra" short="FB" refNr="23" scheduleFile="g23_____.abf" localOrderFile="bf23____.ABF">
     <track name="1">
       <block name="23G1" />
       <alternative track="2" />

--- a/Leibit.Core/Data/nhth/FB.xml
+++ b/Leibit.Core/Data/nhth/FB.xml
@@ -331,7 +331,7 @@
     </track>
   </station>
 
-  <station name="Friedlos Hp" short="FFL" refNr="17" scheduleFile="v17_____.abf">
+  <station name="Friedlos" short="FFL" refNr="17" scheduleFile="v17_____.abf">
     <track name="2" calculateDelay="false">
       <block name="17S533" />
     </track>
@@ -340,14 +340,14 @@
     </track>
   </station>
 
-  <station name="Abzw Faßdorf" short="FFDF" refNr="21" scheduleFile="g21_____.abf">
+  <station name="Faßdorf" short="FFDF" refNr="21" scheduleFile="g21_____.abf">
     <track name="918" calculateDelay="false" />
     <track name="919" calculateDelay="false" />
     <track name="983" calculateDelay="false" />
     <track name="984" calculateDelay="false" />
   </station>
 
-  <station name="Ronshausen Hp" short="FRON" refNr="21" scheduleFile="ronsha__.abf">
+  <station name="Ronshausen" short="FRON" refNr="21" scheduleFile="ronsha__.abf">
     <track name="1" calculateDelay="false">
       <block name="21B617" />
     </track>
@@ -375,7 +375,7 @@
     </track>
   </station>
 
-  <station name="Bosserode Hp" short="FBOS" refNr="20" scheduleFile="bosser__.abf">
+  <station name="Bosserode" short="FBOS" refNr="20" scheduleFile="bosser__.abf">
     <track name="1" calculateDelay="false">
       <block name="20B611" />
     </track>
@@ -384,7 +384,7 @@
     </track>
   </station>
 
-  <station name="Obersuhl Hp" short="FOBS" refNr="97" scheduleFile="Obersu__.ABF">
+  <station name="Obersuhl" short="FOBS" refNr="97" scheduleFile="Obersu__.ABF">
     <track name="1" calculateDelay="false">
       <block name="97B609" />
     </track>
@@ -400,12 +400,12 @@
     </track>
   </station>
 
-  <station name="Rotenburg Hp" short="FROF" refNr="24" scheduleFile="rotenb__.abf">
+  <station name="Rotenburg (Fulda)" short="FROF" refNr="24" scheduleFile="rotenb__.abf">
     <track name="1" calculateDelay="false" />
     <track name="2" calculateDelay="false" />
   </station>
 
-  <station name="Lispenhausen Hp" short="FLIH" refNr="24" scheduleFile="lispen__.abf">
+  <station name="Lispenhausen" short="FLIH" refNr="24" scheduleFile="lispen__.abf">
     <track name="1" calculateDelay="false" />
     <track name="2" calculateDelay="false" />
   </station>

--- a/Leibit.Core/Data/nhth/FBHF.xml
+++ b/Leibit.Core/Data/nhth/FBHF.xml
@@ -7,7 +7,7 @@
     </track>
   </station>
 
-  <station name="Marbach" short="FMR" refNr="12" scheduleFile="G12_____.ABF">
+  <station name="Marbach (Kr Fulda)" short="FMR" refNr="12" scheduleFile="G12_____.ABF">
     <track name="801">
       <block name="12G801"/>
     </track>
@@ -40,7 +40,7 @@
     </track>
   </station>
 
-  <station name="Burghaun" short="FBUH" refNr="14" scheduleFile="G14_____.ABF">
+  <station name="Burghaun (Kr Hünfeld)" short="FBUH" refNr="14" scheduleFile="G14_____.ABF">
     <track name="951">
       <block name="14G951"/>
     </track>
@@ -49,7 +49,7 @@
     </track>
   </station>
 
-  <station name="Neukirchen" short="FNK" refNr="15" scheduleFile="G15_____.ABF">
+  <station name="Haunetal-Neukirchen" short="FNK" refNr="15" scheduleFile="G15_____.ABF">
     <track name="1">
       <block name="15G1"/>
     </track>

--- a/Leibit.Core/Data/nhth/FBHF.xml
+++ b/Leibit.Core/Data/nhth/FBHF.xml
@@ -148,7 +148,7 @@
     </track>
   </station>
 
-  <station name="Friedlos Hp" short="FFL" refNr="17" scheduleFile="b17_____.abf">
+  <station name="Friedlos" short="FFL" refNr="17" scheduleFile="b17_____.abf">
     <track name="1" calculateDelay="false">
       <block name="17B546"/>
     </track>
@@ -207,7 +207,7 @@
     </track>
   </station>
 
-  <station name="Abzw Faßdorf" short="FFDF" refNr="19">
+  <station name="Faßdorf" short="FFDF" refNr="19">
     <track isPlatform="false" calculateDelay="false">
       <block name="19S921" direction="left"/>
     </track>

--- a/Leibit.Core/Data/nhth/FEL.xml
+++ b/Leibit.Core/Data/nhth/FEL.xml
@@ -161,7 +161,7 @@
     </track>
   </station>
 
-  <station name="Üst Katzenberg" short="FKA" refNr="16" scheduleFile="B16_____.ABF">
+  <station name="Katzenberg" short="FKA" refNr="16" scheduleFile="B16_____.ABF">
     <track name="172" calculateDelay="false" isPlatform="false">
       <block name="16B3174" direction="left"/>
       <block name="16B182" direction="right"/>
@@ -220,7 +220,7 @@
     </track>
   </station>
 
-  <station name="Üst Kerzell" short="FKZ" refNr="10">
+  <station name="Kerzell" short="FKZ" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10B682" direction="left"/>
       <block name="10S428" direction="right"/>
@@ -264,7 +264,7 @@
     </track>
   </station>
 
-  <station name="Üst Dittenbrunn" short="NDI" refNr="7" scheduleFile="G7______.ABF" localOrderFile="BF7_____.ABF">
+  <station name="Dittenbrunn" short="NDI" refNr="7" scheduleFile="G7______.ABF" localOrderFile="BF7_____.ABF">
     <track name="188" isPlatform="false">
       <block name="07B292" direction="left"/>
       <block name="07B388" direction="right"/>
@@ -275,7 +275,7 @@
     </track>
   </station>
 
-  <station name="Üst Altengronau" short="NAG" refNr="8" scheduleFile="G8______.ABF" localOrderFile="BF8_____.ABF">
+  <station name="Altengronau" short="NAG" refNr="8" scheduleFile="G8______.ABF" localOrderFile="BF8_____.ABF">
     <track name="174" isPlatform="false">
       <block name="08B282" direction="left"/>
       <block name="08B374" direction="right"/>
@@ -301,7 +301,7 @@
     </track>
   </station>
 
-  <station name="Üst Landrücken Süd" short="FLRS" refNr="10">
+  <station name="Landrücken Süd" short="FLRS" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10S655" direction="left"/>
       <block name="10S656" direction="left"/>

--- a/Leibit.Core/Data/nhth/FEL.xml
+++ b/Leibit.Core/Data/nhth/FEL.xml
@@ -11,7 +11,7 @@
     <track name="351" calculateDelay="false" />
   </station>
 
-  <station name="Sinnberg" short="NSB" refNr="11" scheduleFile="G11_____.ABF">
+  <station name="Rieneck Sinnberg" short="NSB" refNr="11" scheduleFile="G11_____.ABF">
     <track name="242" isPlatform="false">
       <block name="11B52" direction="left"/>
       <block name="11B342" direction="right"/>
@@ -153,7 +153,7 @@
     </track>
   </station>
 
-  <station name="Schlüchtern-Ziegenberg" short="FSUEZ" refNr="66">
+  <station name="Ziegenberg (Schlüchtern)" short="FSUEZ" refNr="66">
     <track calculateDelay="false" isPlatform="false">
       <block name="15B001" direction="left"/>
       <block name="66B171" direction="right"/>
@@ -196,7 +196,7 @@
     </track>
   </station>
 
-  <station name="Neuhof" short="FNF" refNr="17" scheduleFile="G17_____.ABF" localOrderFile="BF17____.ABF">
+  <station name="Neuhof (Kr Fulda)" short="FNF" refNr="17" scheduleFile="G17_____.ABF" localOrderFile="BF17____.ABF">
     <track name="001">
       <block name="17G001"/>
     </track>
@@ -208,7 +208,7 @@
     </track>
   </station>
 
-  <station name="Neuhof-Nord" short="FNF N" refNr="17" scheduleFile="B17_____.ABF">
+  <station name="Neuhof Nord" short="FNF N" refNr="17" scheduleFile="B17_____.ABF">
     <track name="801">
       <block name="17G801"/>
     </track>
@@ -229,7 +229,7 @@
     </track>
   </station>
 
-  <station name="Fulda-Bronzell" short="FFU B" refNr="10">
+  <station name="Fulda Bronzell" short="FFU B" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10S426" direction="left"/>
       <block name="10S443" direction="left"/>
@@ -301,7 +301,7 @@
     </track>
   </station>
 
-  <station name="Landrücken Süd" short="FLRS" refNr="10">
+  <station name="Sinntal Landrücken Süd" short="FLRS" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10S655" direction="left"/>
       <block name="10S656" direction="left"/>

--- a/Leibit.Core/Data/nhth/FFU.xml
+++ b/Leibit.Core/Data/nhth/FFU.xml
@@ -22,7 +22,7 @@
     </track>
   </station>
 
-  <station name="Landrücken Süd" short="FLRS" refNr="10">
+  <station name="Sinntal Landrücken Süd" short="FLRS" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10B655" direction="left"/>
       <block name="10B656" direction="left"/>
@@ -31,7 +31,7 @@
     </track>
   </station>
 
-  <station name="Landrücken Nord" short="FLRN" refNr="10">
+  <station name="Kalbach Landrücken Nord" short="FLRN" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10B611" direction="left"/>
       <block name="10B612" direction="left"/>
@@ -40,7 +40,7 @@
     </track>
   </station>
 
-  <station name="Hartberg" short="FHAG" refNr="10">
+  <station name="Neuhof Hartberg" short="FHAG" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10B565" direction="left"/>
       <block name="10B566" direction="left"/>
@@ -49,7 +49,7 @@
     </track>
   </station>
 
-  <station name="Neuhof-Nord" short="FNF N" refNr="17">
+  <station name="Neuhof Nord" short="FNF N" refNr="17">
     <track isPlatform="false" calculateDelay="false">
       <block name="17S680" direction="right"/>
       <block name="17S687" direction="right"/>
@@ -67,13 +67,13 @@
     </track>
   </station>
 
-  <station name="Gersfeld" short="FGFD" refNr="10">
+  <station name="Gersfeld (Rhön)" short="FGFD" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10B455" direction="right"/>
     </track>
   </station>
 
-  <station name="Fulda-Bronzell" short="FFU B" refNr="10">
+  <station name="Fulda Bronzell" short="FFU B" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10G403"/>
       <block name="10G437"/>
@@ -497,7 +497,7 @@
     </track>
   </station>
 
-  <station name="Marbach" short="FMR" refNr="12">
+  <station name="Marbach (Kr Fulda)" short="FMR" refNr="12">
     <track isPlatform="false" calculateDelay="false">
       <block name="11B713" direction="left"/>
       <block name="12B823" direction="left"/>

--- a/Leibit.Core/Data/nhth/FFU.xml
+++ b/Leibit.Core/Data/nhth/FFU.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <estw>
-  <station name="Üst Altengronau" short="NAG" refNr="08">
+  <station name="Altengronau" short="NAG" refNr="08">
     <track isPlatform="false" calculateDelay="false">
       <block name="08S374" direction="right"/>
       <block name="09S273" direction="right"/>
@@ -22,7 +22,7 @@
     </track>
   </station>
 
-  <station name="Üst Landrücken Süd" short="FLRS" refNr="10">
+  <station name="Landrücken Süd" short="FLRS" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10B655" direction="left"/>
       <block name="10B656" direction="left"/>
@@ -31,7 +31,7 @@
     </track>
   </station>
 
-  <station name="Üst Landrücken Nord" short="FLRN" refNr="10">
+  <station name="Landrücken Nord" short="FLRN" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10B611" direction="left"/>
       <block name="10B612" direction="left"/>
@@ -40,7 +40,7 @@
     </track>
   </station>
 
-  <station name="Üst Hartberg" short="FHAG" refNr="10">
+  <station name="Hartberg" short="FHAG" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10B565" direction="left"/>
       <block name="10B566" direction="left"/>
@@ -56,7 +56,7 @@
     </track>
   </station>
 
-  <station name="Üst Kerzell" short="FKZ" refNr="10" scheduleFile="B09_____.ABF">
+  <station name="Kerzell" short="FKZ" refNr="10" scheduleFile="B09_____.ABF">
     <track name="428" isPlatform="false" calculateDelay="false">
       <block name="10B682" direction="left"/>
       <block name="10B428" direction="right"/>
@@ -504,7 +504,7 @@
     </track>
   </station>
 
-  <station name="Üst Dietershan" short="FDIE" refNr="10">
+  <station name="Dietershan" short="FDIE" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10B17" direction="left"/>
       <block name="10B18" direction="left"/>
@@ -513,7 +513,7 @@
     </track>
   </station>
 
-  <station name="Üst Michelsrombach" short="FMIR" refNr="10">
+  <station name="Michelsrombach" short="FMIR" refNr="10">
     <track isPlatform="false" calculateDelay="false">
       <block name="10B505" direction="left"/>
       <block name="10B506" direction="left"/>
@@ -540,7 +540,7 @@
     </track>
   </station>
 
-  <station name="Üst Richthof" short="FRIH" refNr="20">
+  <station name="Richthof" short="FRIH" refNr="20">
     <track isPlatform="false" calculateDelay="false">
       <block name="10S590" direction="left"/>
       <block name="10S674" direction="left"/>

--- a/Leibit.Core/Data/nhth/FGEL.xml
+++ b/Leibit.Core/Data/nhth/FGEL.xml
@@ -23,7 +23,7 @@
     </track>
   </station>
 
-  <station name="Abzw Rauschwald" short="FRW" refNr="36" scheduleFile="G36_____.abf">
+  <station name="Rauschwald" short="FRW" refNr="36" scheduleFile="G36_____.abf">
     <track name="101" isPlatform="false">
       <block name="58B01" direction="right"/>
       <block name="64B62" direction="left"/>
@@ -60,7 +60,7 @@
     </track>
   </station>
 
-  <station name="Rodenbach Hp" short="FROD" refNr="58" scheduleFile="B58_____.abf">
+  <station name="Rodenbach" short="FROD" refNr="58" scheduleFile="B58_____.abf">
     <track name="065" calculateDelay="false">
       <block name="58B65"/>
     </track>
@@ -87,7 +87,7 @@
     </track>
   </station>
 
-  <station name="Niedermittlau Hp" short="FNMI" refNr="59" scheduleFile="B59_____.abf">
+  <station name="Niedermittlau" short="FNMI" refNr="59" scheduleFile="B59_____.abf">
     <track name="075" calculateDelay="false">
       <block name="59B75"/>
     </track>
@@ -209,7 +209,7 @@
     </track>
   </station>
 
-  <station name="Haitz-Höchst Hp" short="FHAI" refNr="62" scheduleFile="B62_____.ABF">
+  <station name="Haitz-Höchst" short="FHAI" refNr="62" scheduleFile="B62_____.ABF">
     <track name="93" calculateDelay="false">
       <block name="62S93"/>
     </track>

--- a/Leibit.Core/Data/nhth/FGEL.xml
+++ b/Leibit.Core/Data/nhth/FGEL.xml
@@ -45,7 +45,7 @@
     </track>
   </station>
 
-  <station name="Hanau-Wolfgang" short="FWFG" refNr="58" scheduleFile="G58_____.ABF" localOrderFile="bf58____.abf">
+  <station name="Wolfgang (Kr Hanau)" short="FWFG" refNr="58" scheduleFile="G58_____.ABF" localOrderFile="bf58____.abf">
     <track name="001">
       <block name="58G001"/>
     </track>

--- a/Leibit.Core/Data/nhth/FGK.xml
+++ b/Leibit.Core/Data/nhth/FGK.xml
@@ -14,7 +14,7 @@
     </track>
   </station>
 
-  <station name="Hanau-Großauheim" short="FGAU" refNr="65" scheduleFile="G65_____.abf" localOrderFile="bf65____.abf">
+  <station name="Großauheim (Kr Hanau)" short="FGAU" refNr="65" scheduleFile="G65_____.abf" localOrderFile="bf65____.abf">
     <track name="001">
       <block name="65G001"/>
     </track>
@@ -83,7 +83,7 @@
     </track>
   </station>
 
-  <station name="Alzenau" short="FAZU" refNr="67">
+  <station name="Alzenau (Unterfr)" short="FAZU" refNr="67">
     <track calculateDelay="false" isPlatform="false">
       <block name="67B01"/>
     </track>
@@ -126,7 +126,7 @@
     </track>
   </station>
 
-  <station name="Dettingen" short="FDET" refNr="68" scheduleFile="G68_____.abf" localOrderFile="bf68____.abf">
+  <station name="Dettingen (Main)" short="FDET" refNr="68" scheduleFile="G68_____.abf" localOrderFile="bf68____.abf">
     <track name="001">
       <block name="68G001"/>
       <alternative track="002"/>
@@ -233,7 +233,7 @@
     <track name="104" isPlatform="false"/>
   </station>
 
-  <station name="Stockstadt" short="FSTK" refNr="51" scheduleFile="g51_____.abf" localOrderFile="bf51____.abf">
+  <station name="Stockstadt (Main)" short="FSTK" refNr="51" scheduleFile="g51_____.abf" localOrderFile="bf51____.abf">
     <track name="001">
       <block name="51G001"/>
       <alternative track="002"/>
@@ -264,7 +264,7 @@
     </track>
   </station>
 
-  <station name="Babenhausen" short="FBA" refNr="50">
+  <station name="Babenhausen (Hessen)" short="FBA" refNr="50">
     <track calculateDelay="false" isPlatform="false">
       <block name="51B01" direction="right"/>
       <block name="51B02" direction="right"/>

--- a/Leibit.Core/Data/nhth/FGK.xml
+++ b/Leibit.Core/Data/nhth/FGK.xml
@@ -7,7 +7,7 @@
     </track>
   </station>
 
-  <station name="Abzw Rauschwald" short="FRW" refNr="36">
+  <station name="Rauschwald" short="FRW" refNr="36">
     <track calculateDelay="false" isPlatform="false">
       <block name="36B01" direction="right"/>
       <block name="66B02" direction="right"/>
@@ -149,7 +149,7 @@
     </track>
   </station>
 
-  <station name="Rückersbacher Schlucht Hp" short="FRS" refNr="68" scheduleFile="B68_____.abf">
+  <station name="Rückersbacher Schlucht" short="FRS" refNr="68" scheduleFile="B68_____.abf">
     <track name="001" calculateDelay="false">
       <block name="68B81"/>
     </track>
@@ -170,7 +170,7 @@
     </track>
   </station>
 
-  <station name="Abzw Steinerts" short="FSTE" refNr="70" scheduleFile="G70_____.abf" localOrderFile="bf70____.abf">
+  <station name="Steinerts" short="FSTE" refNr="70" scheduleFile="G70_____.abf" localOrderFile="bf70____.abf">
     <track name="101" isPlatform="false">
       <block name="69B91" direction="left"/>
     </track>
@@ -198,7 +198,7 @@
     </track>
   </station>
 
-  <station name="Abzw Mainaschaff Hp" short="FMAS" refNr="52" scheduleFile="g52_____.abf" localOrderFile="bf52____.abf">
+  <station name="Mainaschaff" short="FMAS" refNr="52" scheduleFile="g52_____.abf" localOrderFile="bf52____.abf">
     <track name="101" isPlatform="false">
       <block name="51B11" direction="left"/>
       <alternative track="102"/>

--- a/Leibit.Core/Data/nhth/FSUE.xml
+++ b/Leibit.Core/Data/nhth/FSUE.xml
@@ -129,7 +129,7 @@
     </track>
   </station>
 
-  <station name="Schlüchtern-Ziegenberg" short="FSUEZ" refNr="66" scheduleFile="B66_____.ABF">
+  <station name="Ziegenberg (Schlüchtern)" short="FSUEZ" refNr="66" scheduleFile="B66_____.ABF">
     <track name="301" isPlatform="false">
       <block name="15B01" direction="right"/>
     </track>

--- a/Leibit.Core/Data/nhth/FSUE.xml
+++ b/Leibit.Core/Data/nhth/FSUE.xml
@@ -7,7 +7,7 @@
     </track>
   </station>
 
-  <station name="Haitz-Höchst Hp" short="FHAI" refNr="62" scheduleFile="B62_____.ABF">
+  <station name="Haitz-Höchst" short="FHAI" refNr="62" scheduleFile="B62_____.ABF">
     <track name="93" calculateDelay="false">
       <block name="62B93"/>
     </track>
@@ -151,7 +151,7 @@
     </track>
   </station>
 
-  <station name="Üst Katzenberg" short="FKA" refNr="16">
+  <station name="Katzenberg" short="FKA" refNr="16">
     <track calculateDelay="false" isPlatform="false">
       <block name="16S2173" direction="left"/>
       <block name="16S3174" direction="left"/>

--- a/Leibit.Core/Data/nhth/NAH.xml
+++ b/Leibit.Core/Data/nhth/NAH.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <estw>
-  <station name="Abzw Mainaschaff Hp" short="FMAS" refNr="52" scheduleFile="b52_____.abf">
+  <station name="Mainaschaff" short="FMAS" refNr="52" scheduleFile="b52_____.abf">
     <track name="001">
       <block name="52S001"/>
     </track>
@@ -9,7 +9,7 @@
     </track>
   </station>
   
-  <station name="Abzw Steinerts" short="FSTE" refNr="70">
+  <station name="Steinerts" short="FSTE" refNr="70">
     <track calculateDelay="false" isPlatform="false">
       <block name="70B01" direction="right"/>
       <block name="71B02" direction="right"/>
@@ -288,7 +288,7 @@
     </track>
   </station>
   
-  <station name="Abzw Aschaffenburg-Goldbach" short="NAH G" refNr="71" scheduleFile="b71_____.abf">
+  <station name="Aschaffenburg-Goldbach" short="NAH G" refNr="71" scheduleFile="b71_____.abf">
     <track name="112" isPlatform="false">
       <block name="71G0212" direction="left"/>
     </track>

--- a/Leibit.Core/Data/nhth/NAH.xml
+++ b/Leibit.Core/Data/nhth/NAH.xml
@@ -376,7 +376,7 @@
     </track>
   </station>
 
-  <station name="Klingenberg" short="NKM" refNr="56">
+  <station name="Klingenberg (Main)" short="NKM" refNr="56">
     <track calculateDelay="false" isPlatform="false">
       <block name="55B61" direction="left"/>
     </track>

--- a/Leibit.Core/Data/nhth/NGM.xml
+++ b/Leibit.Core/Data/nhth/NGM.xml
@@ -16,7 +16,7 @@
     </track>
   </station>
 
-  <station name="Sinnberg" short="NSB" refNr="11">
+  <station name="Rieneck Sinnberg" short="NSB" refNr="11">
     <track calculateDelay="false" isPlatform="false">
       <block name="11S52" direction="right"/>
       <block name="11B351" direction="right"/>

--- a/Leibit.Core/Data/nhth/NHEI.xml
+++ b/Leibit.Core/Data/nhth/NHEI.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?> 
 <estw>
-  <station name="Abzw Aschaffenburg-Goldbach" short="NAH G" refNr="71">
+  <station name="Aschaffenburg-Goldbach" short="NAH G" refNr="71">
     <track calculateDelay="false" isPlatform="false">
       <block name="71B374" direction="right"/>
       <block name="72B73" direction="right"/>

--- a/Leibit.Core/Data/nhth/NHEI.xml
+++ b/Leibit.Core/Data/nhth/NHEI.xml
@@ -41,7 +41,7 @@
     </track>
   </station>
 
-  <station name="Heigenbrücken-West" short="NHEIW" refNr="74" scheduleFile="b74_____.abf" localOrderFile="b74_____.abf">
+  <station name="Heigenbrücken West" short="NHEIW" refNr="74" scheduleFile="b74_____.abf" localOrderFile="b74_____.abf">
     <track name="403">
       <block name="74G403"/>
     </track>

--- a/Leibit.Core/Data/nhth/NLO.xml
+++ b/Leibit.Core/Data/nhth/NLO.xml
@@ -25,7 +25,7 @@
     </track>
   </station>
 
-  <station name="Lohr" short="NLO" refNr="77" scheduleFile="g77_____.abf" localOrderFile="bf77____.abf">
+  <station name="Lohr Bahnhof" short="NLO" refNr="77" scheduleFile="g77_____.abf" localOrderFile="bf77____.abf">
     <track name="001">
       <block name="77G001"/>
     </track>
@@ -132,7 +132,7 @@
     </track>
   </station>
 
-  <station name="Neuberg" short="NNB" refNr="1" scheduleFile="g1______.abf" localOrderFile="bf1_____.abf">
+  <station name="Margetshöchheim Neuberg" short="NNB" refNr="1" scheduleFile="g1______.abf" localOrderFile="bf1_____.abf">
     <track name="146" isPlatform="false">
       <block name="01B252" direction="right"/>
       <block name="01B346" direction="left"/>

--- a/Leibit.Core/Data/nhth/NLO.xml
+++ b/Leibit.Core/Data/nhth/NLO.xml
@@ -65,7 +65,7 @@
     </track>
   </station>
 
-  <station name="Üst Dittenbrunn" short="NDI" refNr="7">
+  <station name="Dittenbrunn" short="NDI" refNr="7">
     <track calculateDelay="false" isPlatform="false">
       <block name="06S91" direction="right"/>
       <block name="06S92" direction="right"/>

--- a/Leibit.Core/Data/nhth/NWH.xml
+++ b/Leibit.Core/Data/nhth/NWH.xml
@@ -7,7 +7,7 @@
     </track>
   </station>
 
-  <station name="Neuberg" short="NNB" refNr="1" scheduleFile="g1______.abf">
+  <station name="Margetshöchheim Neuberg" short="NNB" refNr="1" scheduleFile="g1______.abf">
     <track name="146" isPlatform="false">
       <block name="01S252" direction="right"/>
       <block name="01S346" direction="left"/>

--- a/Leibit.Core/Data/nhth/UEI.xml
+++ b/Leibit.Core/Data/nhth/UEI.xml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <estw>
-  <station name="Heringen" short="FHRG" refNr="98">
+  <station name="Heringen (Werra)" short="FHRG" refNr="98">
     <track isPlatform="false" calculateDelay="false">
       <block name="97B99" direction="right" />
     </track>
   </station>
 
-  <station name="Förtha" short="UF" refNr="39">
+  <station name="Förtha (Kr Eisenach)" short="UF" refNr="39">
     <track isPlatform="false" calculateDelay="false">
       <block name="94B42" direction="right" />
     </track>
@@ -121,7 +121,7 @@
     </track>
   </station>
 
-  <station name="Eisenach Pbf/Gbf" short="UEI" refNr="94" scheduleFile="G94_____.ABF" localOrderFile="bf94____.abf">
+  <station name="Eisenach" short="UEI" refNr="94" scheduleFile="G94_____.ABF" localOrderFile="bf94____.abf">
     <track name="401">
       <block name="94G401" />
       <alternative track="402" />

--- a/Leibit.Core/Data/nhth/UEI.xml
+++ b/Leibit.Core/Data/nhth/UEI.xml
@@ -19,7 +19,7 @@
     </track>
   </station>
 
-  <station name="Bosserode Hp" short="FBOS" refNr="20" scheduleFile="BOSSER__.ABF">
+  <station name="Bosserode" short="FBOS" refNr="20" scheduleFile="BOSSER__.ABF">
     <track name="611" calculateDelay="false">
       <block name="20S611" />
     </track>
@@ -28,7 +28,7 @@
     </track>
   </station>
 
-  <station name="Obersuhl Hp" short="FOBS" refNr="97" scheduleFile="OBERSU__.ABF">
+  <station name="Obersuhl" short="FOBS" refNr="97" scheduleFile="OBERSU__.ABF">
     <track name="609" calculateDelay="false">
       <block name="97B609" />
     </track>
@@ -58,7 +58,7 @@
     </track>
   </station>
 
-  <station name="Herleshausen Hp" short="UHER" refNr="97" scheduleFile="Herles__.abf">
+  <station name="Herleshausen" short="UHER" refNr="97" scheduleFile="Herles__.abf">
     <track name="795" calculateDelay="false">
       <block name="97B795" />
     </track>
@@ -79,7 +79,7 @@
     </track>
   </station>
 
-  <station name="Hörschel Hp" short="UHL" refNr="96" scheduleFile="Hörsch__.abf">
+  <station name="Hörschel" short="UHL" refNr="96" scheduleFile="Hörsch__.abf">
     <track name="793" calculateDelay="false">
       <block name="96B793" />
     </track>
@@ -103,7 +103,7 @@
     </track>
   </station>
 
-  <station name="Eisenach-Opelwerk Hp" short="UEIP" refNr="95" scheduleFile="Opelwe__.abf">
+  <station name="Eisenach-Opelwerk" short="UEIP" refNr="95" scheduleFile="Opelwe__.abf">
     <track name="693" calculateDelay="false">
       <block name="95B693" />
     </track>
@@ -112,7 +112,7 @@
     </track>
   </station>
 
-  <station name="Eisenach-West Hp" short="UEIW" refNr="94" scheduleFile="EISENA__.ABF">
+  <station name="Eisenach-West" short="UEIW" refNr="94" scheduleFile="EISENA__.ABF">
     <track name="691" calculateDelay="false">
       <block name="94B691" />
     </track>
@@ -274,7 +274,7 @@
     </track>
   </station>
 
-  <station name="Schönau (Hörsel) Hp" short="USU" refNr="93" scheduleFile="Schöna__.abf">
+  <station name="Schönau (Hörsel)" short="USU" refNr="93" scheduleFile="Schöna__.abf">
     <track name="591" calculateDelay="false">
       <block name="93B591" />
     </track>
@@ -283,7 +283,7 @@
     </track>
   </station>
 
-  <station name="Sättelstädt Hp" short="USAE" refNr="92" scheduleFile="Sättel__.abf">
+  <station name="Sättelstädt" short="USAE" refNr="92" scheduleFile="Sättel__.abf">
     <track name="993" calculateDelay="false">
       <block name="92B993" />
     </track>
@@ -307,7 +307,7 @@
     </track>
   </station>
 
-  <station name="Mechterstädt Hp" short="UME" refNr="91" scheduleFile="Mechte__.abf">
+  <station name="Mechterstädt" short="UME" refNr="91" scheduleFile="Mechte__.abf">
     <track name="991" calculateDelay="false">
       <block name="91B991" />
     </track>
@@ -360,7 +360,7 @@
     </track>
   </station>
 
-  <station name="Hörselgau Hp" short="UHOS" refNr="37" scheduleFile="Hörsel__.abf">
+  <station name="Hörselgau" short="UHOS" refNr="37" scheduleFile="Hörsel__.abf">
     <track name="806" calculateDelay="false">
       <block name="91B806" />
     </track>

--- a/Leibit.Core/Data/nhth/UGO.xml
+++ b/Leibit.Core/Data/nhth/UGO.xml
@@ -177,7 +177,7 @@
     </track>
   </station>
 
-  <station name="Sülzenbrücken Hp" short="USUE" refNr="87" scheduleFile="Sülzen__.abf">
+  <station name="Sülzenbrücken" short="USUE" refNr="87" scheduleFile="Sülzen__.abf">
     <track name="1" calculateDelay="false">
       <block name="87B891" />
     </track>

--- a/Leibit.Core/Data/nord/ABLZ.xml
+++ b/Leibit.Core/Data/nord/ABLZ.xml
@@ -46,7 +46,7 @@
     </track>
   </station>
 
-  <station name="Sprötze Hp" short="ASP" refNr="57" scheduleFile="b57_____.abf">
+  <station name="Sprötze" short="ASP" refNr="57" scheduleFile="b57_____.abf">
     <track name="500" calculateDelay="false">
       <block name="57B500"/>
     </track>

--- a/Leibit.Core/Data/nord/ABLZ.xml
+++ b/Leibit.Core/Data/nord/ABLZ.xml
@@ -58,7 +58,7 @@
     </track>
   </station>
 
-  <station name="Buchholz (Nh)" short="ABLZ" refNr="58" scheduleFile="g58_____.abf" localOrderFile="bf58____.abf">
+  <station name="Buchholz (Nordheide)" short="ABLZ" refNr="58" scheduleFile="g58_____.abf" localOrderFile="bf58____.abf">
     <track name="63">
       <block name="58G63"/>
       <alternative track="64"/>

--- a/Leibit.Core/Data/nord/AH.xml
+++ b/Leibit.Core/Data/nord/AH.xml
@@ -195,7 +195,7 @@
     </track>
   </station>
 
-  <station name="Abzw Hamburg-Wilhelmsburg" short="AWLBA" refNr="63">
+  <station name="Hamburg-Wilhelmsburg Abzw" short="AWLBA" refNr="63">
     <track isPlatform="false" calculateDelay="false">
       <block name="63S409" direction="left"/>
       <block name="63S509" direction="left"/>

--- a/Leibit.Core/Data/nord/AH.xml
+++ b/Leibit.Core/Data/nord/AH.xml
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <estw>
-  <station name="Abzw Rainweg" short="AAR" refNr="23">
+  <station name="Hamburg Rainweg" short="AAR" refNr="23">
     <track isPlatform="false" calculateDelay="false">
       <block name="23S115" direction="right"/>
       <block name="23S560" direction="right"/>
     </track>
   </station>
 
-  <station name="Üst Hamburg Sternschanze" short="ASTZ" refNr="22">
+  <station name="Hamburg Sternschanze" short="ASTZ" refNr="22">
     <track isPlatform="false" calculateDelay="false">
       <block name="23S107"/>
       <block name="22S110"/>
     </track>
   </station>
 
-  <station name="Hamburg Dammtor Hp" short="ADF" refNr="22" scheduleFile="v22_____.abf">
+  <station name="Hamburg Dammtor" short="ADF" refNr="22" scheduleFile="v22_____.abf">
     <track name="103" calculateDelay="false">
       <block name="22S103"/>
     </track>
@@ -99,7 +99,7 @@
     </track>
   </station>
 
-  <station name="Hamburg Hasselbrook Hp" short="AHSF" refNr="20" scheduleFile="b20_____.abf">
+  <station name="Hamburg Hasselbrook" short="AHSF" refNr="20" scheduleFile="b20_____.abf">
     <track name="364" calculateDelay="false">
       <block name="20B364"/>
     </track>
@@ -115,7 +115,7 @@
     </track>
   </station>
 
-  <station name="Üst Hamburg Anckelmannsplatz" short="AAMP" refNr="18" scheduleFile="b18_____.abf">
+  <station name="Hamburg Anckelmannsplatz" short="AAMP" refNr="18" scheduleFile="b18_____.abf">
     <track name="498" isPlatform="false">
       <block name="20B498" direction="left"/>
     </track>
@@ -133,7 +133,7 @@
     </track>
   </station>
 
-  <station name="Abzw Ericus" short="AERI" refNr="20" scheduleFile="b19_____.abf" localOrderFile="ericus__.abf">
+  <station name="Hamburg Ericus" short="AERI" refNr="20" scheduleFile="b19_____.abf" localOrderFile="ericus__.abf">
     <track name="000" isPlatform="false">
       <block name="20B199" direction="right"/>
     </track>
@@ -157,7 +157,7 @@
     </track>
   </station>
 
-  <station name="Abzw Norderelbbrücke" short="ANEB" refNr="20">
+  <station name="Hamburg Norderelbbrücke" short="ANEB" refNr="20">
     <track isPlatform="false" calculateDelay="false">
       <block name="20B416" direction="left"/>
       <block name="20B426" direction="left"/>
@@ -165,7 +165,7 @@
     </track>
   </station>
 
-  <station name="Abzw Oberhafen" short="AOHA" refNr="64" scheduleFile="b64_____.abf">
+  <station name="Hamburg Oberhafen" short="AOHA" refNr="64" scheduleFile="b64_____.abf">
     <track name="031" isPlatform="false">
       <block name="64SK32" direction="left"/>
       <block name="64B529" direction="left"/>
@@ -180,7 +180,7 @@
     <track name="514" isPlatform="false"/>
   </station>
 
-  <station name="Abzw Veddel" short="AVL" refNr="64" scheduleFile="g64_____.abf">
+  <station name="Hamburg-Veddel" short="AVL" refNr="64" scheduleFile="g64_____.abf">
     <track name="012" isPlatform="false">
       <block name="64S002"/>
     </track>
@@ -228,7 +228,7 @@
     </track>
   </station>
 
-  <station name="Abzw Süderelbbrücke" short="ASE" refNr="62">
+  <station name="Hamburg Süderelbbrücke" short="ASE" refNr="62">
     <track isPlatform="false" calculateDelay="false">
       <block name="63S21" direction="left"/>
       <block name="63S22" direction="left"/>

--- a/Leibit.Core/Data/nord/AHAR.xml
+++ b/Leibit.Core/Data/nord/AHAR.xml
@@ -7,7 +7,7 @@
     </track>
   </station>
 
-  <station name="Abzw Ericus" short="AERI" refNr="20">
+  <station name="Hamburg Ericus" short="AERI" refNr="20">
     <track isPlatform="false" calculateDelay="false">
       <block name="20B426" direction="right"/>
       <block name="20B526" direction="right"/>
@@ -30,7 +30,7 @@
     </track>
   </station>
 
-  <station name="Abzw Norderelbbrücke" short="ANEB" refNr="20" scheduleFile="B20_____.ABF">
+  <station name="Hamburg Norderelbbrücke" short="ANEB" refNr="20" scheduleFile="B20_____.ABF">
     <track name="414" isPlatform="false">
       <block name="20B416" direction="left"/>
       <block name="64G034" direction="right"/>
@@ -41,7 +41,7 @@
     </track>
   </station>
 
-  <station name="Abzw Oberhafen" short="AOHA" refNr="64" scheduleFile="B64_____.ABF">
+  <station name="Hamburg Oberhafen" short="AOHA" refNr="64" scheduleFile="B64_____.ABF">
     <track name="031" isPlatform="false">
       <block name="64G041" direction="left"/>
       <block name="64B517" direction="left"/>
@@ -60,7 +60,7 @@
     </track>
   </station>
 
-  <station name="Abzw Veddel" short="AVL" refNr="64" scheduleFile="G64_____.ABF">
+  <station name="Hamburg-Veddel" short="AVL" refNr="64" scheduleFile="G64_____.ABF">
     <track name="012" isPlatform="false">
       <block name="64G002"/>
     </track>
@@ -128,7 +128,7 @@
     </track>
   </station>
 
-  <station name="Abzw Süderelbbrücke" short="ASE" refNr="62" scheduleFile="B62_____.ABF">
+  <station name="Hamburg Süderelbbrücke" short="ASE" refNr="62" scheduleFile="B62_____.ABF">
     <track name="01" isPlatform="false">
       <block name="63G21" direction="left"/>
       <block name="63B93" direction="left"/>
@@ -418,7 +418,7 @@
     </track>
   </station>
 
-  <station name="Hamburg-Unterelbe" short="AHB" refNr="65" scheduleFile="G65_____.ABF" localOrderFile="Bf65____.abf">
+  <station name="Hamburg Unterelbe" short="AHB" refNr="65" scheduleFile="G65_____.ABF" localOrderFile="Bf65____.abf">
     <track name="1">
       <block name="65G1"/>
     </track>

--- a/Leibit.Core/Data/nord/AHAR.xml
+++ b/Leibit.Core/Data/nord/AHAR.xml
@@ -22,7 +22,7 @@
     </track>
   </station>
 
-  <station name="Hamburg-Süd" short="AHBS" refNr="63">
+  <station name="Hamburg Süd" short="AHBS" refNr="63">
     <track isPlatform="false" calculateDelay="false">
       <block name="64BP50" direction="left"/>
       <block name="63B297" direction="right"/>
@@ -75,7 +75,7 @@
     </track>
   </station>
 
-  <station name="Abzw Hamburg-Wilhelmsburg" short="AWLBA" refNr="63" scheduleFile="B63_____.ABF">
+  <station name="Hamburg-Wilhelmsburg Abzw" short="AWLBA" refNr="63" scheduleFile="B63_____.ABF">
     <track name="61" isPlatform="false"/>
 
     <track name="407" isPlatform="false">
@@ -402,7 +402,7 @@
     </track>
   </station>
 
-  <station name="Abzw Meckelfeld" short="AMDA" refNr="45">
+  <station name="Meckelfeld Abzw" short="AMDA" refNr="45">
     <track isPlatform="false" calculateDelay="false">
       <block name="45B189" direction="left"/>
       <block name="62B192" direction="left"/>

--- a/Leibit.Core/Data/nord/AROG.xml
+++ b/Leibit.Core/Data/nord/AROG.xml
@@ -112,7 +112,7 @@
     </track>
   </station>
 
-  <station name="Rotenburg (W)" short="AROG" refNr="54" scheduleFile="g54_____.abf" localOrderFile="bf54____.abf">
+  <station name="Rotenburg (Wümme)" short="AROG" refNr="54" scheduleFile="g54_____.abf" localOrderFile="bf54____.abf">
     <track name="21">
       <block name="54G21"/>
       <alternative track="22"/>

--- a/Leibit.Core/Data/nord/AROG.xml
+++ b/Leibit.Core/Data/nord/AROG.xml
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <estw>
-  <station name="Abzw Utbremen" short="HUTB" refNr="13">
+  <station name="Bremen Utbremen" short="HUTB" refNr="13">
     <track isPlatform="false" calculateDelay="false">
       <block name="13B961" direction="right"/>
       <block name="13B964" direction="right"/>
     </track>
   </station>
 
-  <station name="Abzw Gabelung" short="HGA" refNr="36">
+  <station name="Bremen Gabelung" short="HGA" refNr="36">
     <track isPlatform="false" calculateDelay="false">
       <block name="36BS" direction="right"/>
       <block name="51B42" direction="right"/>

--- a/Leibit.Core/Data/nord/HB.xml
+++ b/Leibit.Core/Data/nord/HB.xml
@@ -72,7 +72,7 @@
     </track>
   </station>
 
-  <station name="Abzw Bremen-Vahr" short="HVAH" refNr="10" scheduleFile="g10_____.abf" localOrderFile="bf10____.abf">
+  <station name="Bremen-Vahr" short="HVAH" refNr="10" scheduleFile="g10_____.abf" localOrderFile="bf10____.abf">
     <track name="170" isPlatform="false">
       <block name="10B173" direction="right"/>
       <block name="10B161" direction="left"/>
@@ -335,7 +335,7 @@
     </track>
   </station>
 
-  <station name="Bremen-Walle Hp" short="HBWA" refNr="11" scheduleFile="b11_____.abf">
+  <station name="Bremen-Walle" short="HBWA" refNr="11" scheduleFile="b11_____.abf">
     <track name="5" calculateDelay="false">
       <block name="11B204"/>
     </track>
@@ -345,7 +345,7 @@
     </track>
   </station>
 
-  <station name="Abzw Utbremen" short="HUTB" refNr="13" scheduleFile="g13_____.abf" localOrderFile="bf13____.abf">
+  <station name="Bremen Utbremen" short="HUTB" refNr="13" scheduleFile="g13_____.abf" localOrderFile="bf13____.abf">
     <track name="970" isPlatform="false">
       <block name="13B972" direction="left"/>
       <block name="13B964" direction="right"/>


### PR DESCRIPTION
Im echten LeiDis-FI werden Zusätze wie "Abzw", "Üst" und "Hp" nur angezeigt, wenn es mehrere Betriebsstellen mit dem gleichen Namen gibt und der Zusatz zur Unterscheidung notwendig ist. Vor diesem Hintergrund wurden alle Namen von Betriebsstellen überarbeitet. Siehe auch Diskussion in #69 

@dfoehl Wäre super, wenn du hier mal drüber schauen könntest.