### PR TITLE
Fix NullReferenceException in NAH

### DIFF
--- a/Leibit.Client.WPF/Windows/TrainProgressInformation/ViewModels/TrainProgressInformationViewModel.cs
+++ b/Leibit.Client.WPF/Windows/TrainProgressInformation/ViewModels/TrainProgressInformationViewModel.cs
@@ -595,10 +595,12 @@ namespace Leibit.Client.WPF.Windows.TrainProgressInformation.ViewModels
                     var currentSchedule = liveSchedule.Train.Schedules.LastOrDefault(s => s.IsArrived && s.Schedule.Station.ShortSymbol == liveSchedule.Train.Block.Track.Station.ShortSymbol);
 
                     var isFirstStation = liveSchedule.Train.BlockHistory.Select(b => b.Track.Station).Distinct().Count() == 1
-                        && liveSchedule.Train.Block.Track.CalculateDelay == true
-                        && liveSchedule.Train.Block.Track.IsPlatform == true;
+                        && liveSchedule.Train.Block.Track.CalculateDelay
+                        && liveSchedule.Train.Block.Track.IsPlatform;
 
-                    if (currentSchedule?.Schedule.Handling == eHandling.Start)
+                    if (currentSchedule?.Schedule.Departure == null)
+                        isFirstStation = false;
+                    else if (currentSchedule?.Schedule.Handling == eHandling.Start)
                         isFirstStation = true;
                     else if (liveSchedule.Train.CreatedOn == liveSchedule.Train.Block.Track.Station.ESTW.StartTime)
                         isFirstStation = false;

--- a/Leibit.Core/Data/nhth/FGK.xml
+++ b/Leibit.Core/Data/nhth/FGK.xml
@@ -209,14 +209,14 @@
       <alternative track="101"/>
     </track>
 
-    <track name="001">
+    <track name="001" calculateDelay="false">
       <block name="52G001"/>
       <alternative track="002"/>
       <alternative track="103"/>
       <alternative track="104"/>
     </track>
 
-    <track name="002">
+    <track name="002" calculateDelay="false">
       <block name="52G002"/>
       <alternative track="001"/>
       <alternative track="103"/>

--- a/Leibit.Core/Data/nhth/NAH.xml
+++ b/Leibit.Core/Data/nhth/NAH.xml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <estw>
-  <station name="Mainaschaff" short="FMAS" refNr="52" scheduleFile="b52_____.abf">
-    <track name="001">
+  <station name="Mainaschaff" short="FMAS" refNr="52" scheduleFile="v52_____.abf">
+    <track name="001" calculateDelay="false">
       <block name="52S001"/>
     </track>
-    <track name="002">
+    <track name="002" calculateDelay="false">
       <block name="52S002"/>
     </track>
   </station>


### PR DESCRIPTION
Im Stellwerk Aschaffenburg kam es zu einer NullReferenceException, wenn Züge aus Richtung Stockstadt zuliefen. Ursache war eine fehlerhafte Projektierung des Abzw-Hp Mainaschaff.

> Application: LeiBIT.exe
CoreCLR Version: 4.700.21.6504
.NET Core Version: 3.1.12
Description: The process was terminated due to an unhandled exception.
Exception Info: System.NullReferenceException: Object reference not set to an instance of an object.
   at Leibit.Client.WPF.Windows.TrainProgressInformation.ViewModels.TrainProgressInformationViewModel.__BuildEntry(Schedule schedule, LiveSchedule liveSchedule, Settings settings)
   at Leibit.Client.WPF.Windows.TrainProgressInformation.ViewModels.TrainProgressInformationViewModel.Refresh(Area Area)
   at System.Collections.Generic.List\`1.ForEach(Action\`1 action)
   at Leibit.Client.WPF.ViewModels.MainViewModel.__Refresh(Area Area, CancellationToken cancellationToken)
   at Leibit.Client.WPF.ViewModels.MainViewModel.<__Initialize>b__122_0()
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ThreadHelper.ThreadStart()