### PR TITLE
Implemented old format of local orders file

### DIFF
--- a/Leibit.BLL/InitializationBLL.cs
+++ b/Leibit.BLL/InitializationBLL.cs
@@ -584,19 +584,35 @@ namespace Leibit.BLL
                 while (!reader.EndOfStream)
                 {
                     var Line = reader.ReadLine();
-                    var LineParts = Line.Split(' ');
 
-                    if (LineParts[0].IsNotNullOrEmpty())
+                    if (Line.StartsWith("*"))
                     {
-                        __SetLocalOrders(station, CurrentTrainNumber, Content.ToString());
-                        CurrentTrainNumber = 0;
-                        Content = new StringBuilder();
+                        var match = Regex.Match(Line, @"^\*( )+[a-z]+( )+([0-9]+)( )*:", RegexOptions.IgnoreCase);
+
+                        if (match != null && match.Success)
+                        {
+                            if (int.TryParse(match.Groups[3].Value, out int TrainNumber))
+                            {
+                                __SetLocalOrders(station, CurrentTrainNumber, Content.ToString());
+                                CurrentTrainNumber = TrainNumber;
+                                Content = new StringBuilder();
+                            }
+                        }
                     }
+                    else
+                    {
+                        var LineParts = Line.Split(' ');
 
-                    int TrainNumber;
+                        if (LineParts[0].IsNotNullOrEmpty())
+                        {
+                            __SetLocalOrders(station, CurrentTrainNumber, Content.ToString());
+                            CurrentTrainNumber = 0;
+                            Content = new StringBuilder();
+                        }
 
-                    if (Int32.TryParse(LineParts[0], out TrainNumber))
-                        CurrentTrainNumber = TrainNumber;
+                        if (int.TryParse(LineParts[0], out int TrainNumber))
+                            CurrentTrainNumber = TrainNumber;
+                    }
 
                     Content.AppendLine(Line);
                 }

--- a/Leibit.Tests/ExpectedData/ExpectedValuesOfInitializationBLLTest.cs
+++ b/Leibit.Tests/ExpectedData/ExpectedValuesOfInitializationBLLTest.cs
@@ -145,14 +145,14 @@ namespace Leibit.Tests.ExpectedData
             var area = new Area("scheduleArea", "Schedules");
             var estw = new ESTW("ST", "ScheduleTest", "leibit_ST.dat", area);
 
-            var station1 = new Station("Station1", "S1", 1, null, null, estw);
+            var station1 = new Station("Station1", "S1", 1, null, "bf1_____.abf", estw);
             var track1 = new Track("1", true, true, station1, null);
             var track2 = new Track("2", true, true, station1, null);
             var track3 = new Track("3", true, true, station1, null);
 
             var train111 = new Train(111, "RE", "A-Dorf", "B-Heim");
             area.Trains.TryAdd(111, train111);
-            new Schedule(train111, null, new LeibitTime(0, 10), track1, _ALL_DAYS, eScheduleDirection.RightToLeft, eHandling.Transit, String.Empty, null);
+            new Schedule(train111, null, new LeibitTime(0, 10), track1, _ALL_DAYS, eScheduleDirection.RightToLeft, eHandling.Transit, String.Empty, "* RE  111 :  tgl\r\n             -> Durchfahrt Gl. 1");
 
             var train222 = new Train(222, "RE", "B-Heim", "A-Dorf");
             area.Trains.TryAdd(222, train222);
@@ -160,7 +160,7 @@ namespace Leibit.Tests.ExpectedData
 
             var train333 = new Train(333, "RE", "B-Heim", "A-Dorf");
             area.Trains.TryAdd(333, train333);
-            new Schedule(train333, null, new LeibitTime(0, 30), track2, _ALL_DAYS, eScheduleDirection.LeftToRight, eHandling.Transit, String.Empty, null);
+            new Schedule(train333, null, new LeibitTime(0, 30), track2, _ALL_DAYS, eScheduleDirection.LeftToRight, eHandling.Transit, String.Empty, "* RE  333 :  tgl\r\n             -> Durchfahrt Gl. 2");
 
             var train444 = new Train(444, "RE", "A-Dorf", "B-Heim");
             area.Trains.TryAdd(444, train444);

--- a/Leibit.Tests/Leibit.Tests.csproj
+++ b/Leibit.Tests/Leibit.Tests.csproj
@@ -544,6 +544,9 @@
     <None Update="TestData\ESTWOnline\TestMisdirectedTrain\TestdorfDeparture.dat">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\ESTWRoots\ScheduleTest\Bahnhof Anweisungen\bf1_____.abf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\ESTWRoots\ScheduleTest\Bahnhof Fahrplan\G1______.dat">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Leibit.Tests/TestData/ESTWRoots/ScheduleTest/Bahnhof Anweisungen/bf1_____.abf
+++ b/Leibit.Tests/TestData/ESTWRoots/ScheduleTest/Bahnhof Anweisungen/bf1_____.abf
@@ -1,0 +1,17 @@
+﻿Station 1
+
+(detaillierte Anweisungen siehe besondere Rangierpläne)
+
+00 Uhr - 06 UHR
+===============
+
+* RE  111 :  tgl
+             -> Durchfahrt Gl. 1
+
+* RE  333 :  tgl
+             -> Durchfahrt Gl. 2
+
+06 Uhr - 12 UHR
+===============
+
+* Tfzf 77000 bis Tfzf 77999 - Überführungsfahrten von/zur Wartung:

--- a/Leibit.Tests/TestData/ST.xml
+++ b/Leibit.Tests/TestData/ST.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <estw>
-  <station name="Station1" short="S1" refNr="1">
+  <station name="Station1" short="S1" refNr="1" localOrderFile="bf1_____.abf">
     <scheduleFile fileName="G1______.dat"/>
     <scheduleFile fileName="G2______.dat">
       <track>3</track>


### PR DESCRIPTION
Old simulations might have a different format in their local orders files.

New format:

```
21357 RE   Mo       Tfz:218     -Tfz 218 mit Wg. nach 50G75 für RE21407
                                -Tfz 218 v. Schl.Zug nach 50BWE
```

Old format:
```
* Lz  60340 :  Di-Sa
             -> für Rgd2
```