### PR TITLE
Add tooltips in ZFI

### DIFF
--- a/Leibit.Client.WPF/Windows/TrainProgressInformation/ViewModels/TrainProgressInformationViewModel.cs
+++ b/Leibit.Client.WPF/Windows/TrainProgressInformation/ViewModels/TrainProgressInformationViewModel.cs
@@ -583,9 +583,15 @@ namespace Leibit.Client.WPF.Windows.TrainProgressInformation.ViewModels
                 var unjustifiedDelays = delays.Where(d => d.Reason.IsNullOrWhiteSpace() && d.Schedule.Schedule.Station.ESTW.Stations.Any(s => Runtime.VisibleStations.Contains(s)));
 
                 if (unjustifiedDelays.Any())
+                {
                     currentVm.DelayInfo = 'U';
+                    currentVm.DelayDetails = string.Join(Environment.NewLine, unjustifiedDelays.Select(d => $"+{d.Minutes} von {d.Schedule.Schedule.Station.Name}"));
+                }
                 else if (delays.Any(d => d.Reason.IsNotNullOrWhiteSpace()))
+                {
                     currentVm.DelayInfo = 'J';
+                    currentVm.DelayDetails = string.Join(Environment.NewLine, delays.Where(d => d.Reason.IsNotNullOrWhiteSpace()).Select(d => $"+{d.Minutes} von {d.Schedule.Schedule.Station.Name}, Grund: {d.Reason}"));
+                }
                 else
                     currentVm.DelayInfo = ' ';
 

--- a/Leibit.Client.WPF/Windows/TrainProgressInformation/ViewModels/TrainStationViewModel.cs
+++ b/Leibit.Client.WPF/Windows/TrainProgressInformation/ViewModels/TrainStationViewModel.cs
@@ -19,6 +19,7 @@ namespace Leibit.Client.WPF.Windows.TrainProgressInformation.ViewModels
             TrainNumber = schedule.Train.Number;
             Track = schedule.Track;
             LocalOrders = schedule.LocalOrders.IsNotNullOrWhiteSpace() ? 'J' : ' ';
+            LocalOrdersToolTip = schedule.LocalOrders;
 
             Arrival = schedule.Arrival;
             Departure = schedule.Departure;
@@ -287,10 +288,26 @@ namespace Leibit.Client.WPF.Windows.TrainProgressInformation.ViewModels
         }
         #endregion
 
+        #region [DelayDetails]
+        public string DelayDetails
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+        #endregion
+
         #region [LocalOrders]
         public char LocalOrders
         {
             get => Get<char>();
+            set => Set(value);
+        }
+        #endregion
+
+        #region [LocalOrdersToolTip]
+        public string LocalOrdersToolTip
+        {
+            get => Get<string>();
             set => Set(value);
         }
         #endregion

--- a/Leibit.Client.WPF/Windows/TrainProgressInformation/Views/TrainProgressInformationView.xaml
+++ b/Leibit.Client.WPF/Windows/TrainProgressInformation/Views/TrainProgressInformationView.xaml
@@ -122,8 +122,8 @@
             </controls:LeibitDataGridColumn>
             
             <controls:LeibitDataGridColumn Header="vsl. ab" FieldName="ExpectedDeparture" VisibilityBinding="{Binding IsExpectedDepartureVisible, Converter={StaticResource VisibilityConverter}}" />
-            <controls:LeibitDataGridColumn Header="Vsp" FieldName="DelayInfo" TextAlignment="Center" />
-            <controls:LeibitDataGridColumn Header="öAno" FieldName="LocalOrders" TextAlignment="Center" />
+            <controls:LeibitDataGridColumn Header="Vsp" FieldName="DelayInfo" ToolTipFieldName="DelayDetails" TextAlignment="Center" />
+            <controls:LeibitDataGridColumn Header="öAno" FieldName="LocalOrders" ToolTipFieldName="LocalOrdersToolTip" TextAlignment="Center" />
             
             <controls:LeibitDataGridColumn Header="Akt. Betriebsstelle" FieldName="CurrentStation.Name">
                 <controls:LeibitDataGridColumn.BackgroundConditions>

--- a/Leibit.Controls.WPF/LeibitDataGrid/LeibitDataGrid.xaml.cs
+++ b/Leibit.Controls.WPF/LeibitDataGrid/LeibitDataGrid.xaml.cs
@@ -857,6 +857,9 @@ namespace Leibit.Controls
                     if (column.VisibilityBinding != null)
                         gridColumn.ElementStyle.Setters.Add(new Setter(VisibilityProperty, column.VisibilityBinding));
 
+                    if (column.ToolTipFieldName != null)
+                        gridColumn.ElementStyle.Setters.Add(new Setter(ToolTipProperty, new Binding(column.ToolTipFieldName)));
+
                     foreach (var backgroundCondition in column.BackgroundConditions)
                     {
                         Style style;

--- a/Leibit.Controls.WPF/LeibitDataGrid/LeibitDataGridColumn.cs
+++ b/Leibit.Controls.WPF/LeibitDataGrid/LeibitDataGridColumn.cs
@@ -16,6 +16,8 @@ namespace Leibit.Controls
 
         public string FieldName { get; set; }
 
+        public string ToolTipFieldName { get; set; }
+
         public Binding VisibilityBinding { get; set; }
 
         public TextAlignment TextAlignment { get; set; }


### PR DESCRIPTION
Tooltips have been added to display additional information on delays and local orders.