### PR TITLE
Fix InvalidOperationException in case of duplicate schedules

### DIFF
--- a/Leibit.Client.WPF/Windows/TimeTable/ViewModels/TimeTableViewModel.cs
+++ b/Leibit.Client.WPF/Windows/TimeTable/ViewModels/TimeTableViewModel.cs
@@ -180,7 +180,7 @@ namespace Leibit.Client.WPF.Windows.TimeTable.ViewModels
                         if (DelayInfos.Count() > 0)
                             Current.DelayReason = String.Join(", ", DelayInfos);
 
-                        var StartSchedule = LiveTrain.Schedules.SingleOrDefault(s => s.Schedule.Handling == eHandling.Start && s.Schedule.Station == CurrentStation);
+                        var StartSchedule = LiveTrain.Schedules.FirstOrDefault(s => s.Schedule.Handling == eHandling.Start && s.Schedule.Station == CurrentStation);
                         Current.IsReady = StartSchedule != null && StartSchedule.Schedule.Station.ESTW.Time >= StartSchedule.Schedule.Departure.AddMinutes(-2);
                     }
                 }


### PR DESCRIPTION
In Erfurt Gbf there's a bug in the ESTWsim schedule data where one train has a duplicate entries with handling "Start". This led to an exception in the time table view because of the use of "SingleOrDefault".