### PR TITLE
Fix reading of local orders

### DIFF
--- a/Leibit.BLL/InitializationBLL.cs
+++ b/Leibit.BLL/InitializationBLL.cs
@@ -762,7 +762,7 @@ namespace Leibit.BLL
                         NewTrain = false;
                     else
                     {
-                        var match = Regex.Match(Line, @"^\s*([0-9]+)");
+                        var match = Regex.Match(Line, @"^\s{0,4}([0-9]+)");
 
                         if (match != null && match.Success)
                         {


### PR DESCRIPTION
Indentation cannot be more than 4 spaces. Otherwise parts of the local orders would be truncated.

Fixes #277 